### PR TITLE
Fix code scanning alert #2: Multiplication result converted to larger type

### DIFF
--- a/src/lib/core/Particle.cpp
+++ b/src/lib/core/Particle.cpp
@@ -127,7 +127,7 @@ clone(const ParticlesData& other, bool particles, const std::map<std::string, st
         // Copy fixed data
         const void* src = other.fixedData<void>(srcFixedAttr);
         void* dst = p->fixedDataWrite<void>(dstFixedAttr);
-        size_t size = Partio::TypeSize(dstFixedAttr.type) * dstFixedAttr.count;
+        size_t size = static_cast<size_t>(Partio::TypeSize(dstFixedAttr.type)) * dstFixedAttr.count;
         std::memcpy(dst, src, size);
     }
     if (!particles) {


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/partio/security/code-scanning/2](https://github.com/cooljeanius/partio/security/code-scanning/2)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
