### PR TITLE
Fix code scanning alert #1: Multiplication result converted to larger type

### DIFF
--- a/src/lib/core/Particle.cpp
+++ b/src/lib/core/Particle.cpp
@@ -596,7 +596,7 @@ void merge(ParticlesDataMutable& base, const ParticlesData& delta, const std::st
 
         // Copy the attributes to the new/overridden particle
         for (const AttributePair<ParticleAttribute>& attr : attrs) {
-            size_t size = Partio::TypeSize(attr.base.type) * attr.base.count;
+            size_t size = static_cast<size_t>(Partio::TypeSize(attr.base.type)) * attr.base.count;
             void *dst = base.dataWrite<void>(attr.base, index);
             const void* src;
             std::unique_ptr<int[]> newIndices;


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/partio/security/code-scanning/1](https://github.com/cooljeanius/partio/security/code-scanning/1)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
